### PR TITLE
Fix to Visual 2012 build

### DIFF
--- a/include/pcre2.h
+++ b/include/pcre2.h
@@ -89,7 +89,7 @@ will break and the relevant values must be provided by some other means. */
 
 #include <limits.h>
 #include <stdlib.h>
-#if defined(_MSC_VER) && _MSC_VER < 1700
+#if defined(_MSC_VER) && _MSC_VER <= 1700
 #include <stdint.h>
 #else
 #include <inttypes.h>


### PR DESCRIPTION
Visual Studio 2012 also uses stdint.h, so correct check condition to include Visual Studio 2012 for stdint.h branch condition.